### PR TITLE
Added default load of srt font for CLI. 

### DIFF
--- a/processor.py
+++ b/processor.py
@@ -344,7 +344,11 @@ class Utils:
         pos_calc = (left_offset, img.shape[0] - 15)
         pil_im = Image.fromarray(img)
         draw = ImageDraw.Draw(pil_im, 'RGBA')
-        font = ImageFont.truetype("font.ttf", font_size)
+        try:
+            font = ImageFont.truetype("font.ttf", font_size)
+        except OSError:
+            folder, _ = os.path.split(__file__)
+            font = ImageFont.truetype(f"{folder}/resources/font.ttf")
 
         draw.text(pos_calc, line, font=font, fill=(
             255, 255, 255, 255), anchor="lb")


### PR DESCRIPTION
I'm not 100% sure on how the GUI works but it appears the resources files are put into a main directory and then loaded without folder reference. This is a temporary fix that attempts to find it if there's an OSError but long term you'd probably want to be able to specify a particular ttf.